### PR TITLE
Allow use of formatted message in PushoverHandler

### DIFF
--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -30,6 +30,7 @@ class PushoverHandler extends SocketHandler
 
     private $highPriorityLevel;
     private $emergencyLevel;
+    private $useFormattedMessage = false;
 
     /**
      * All parameters that can be sent to Pushover
@@ -103,7 +104,10 @@ class PushoverHandler extends SocketHandler
     {
         // Pushover has a limit of 512 characters on title and message combined.
         $maxMessageLength = 512 - strlen($this->title);
-        $message = substr($record['message'], 0, $maxMessageLength);
+
+        $message = ($this->useFormattedMessage) ? $record['formatted'] : $record['message'];
+        $message = substr($message, 0, $maxMessageLength);
+
         $timestamp = $record['datetime']->getTimestamp();
 
         $dataArray = array(
@@ -168,5 +172,14 @@ class PushoverHandler extends SocketHandler
     public function setEmergencyLevel($value)
     {
         $this->emergencyLevel = $value;
+    }
+
+    /**
+     * Use the formatted message?
+     * @param boolean $value
+     */
+    public function useFormattedMessage($value)
+    {
+        $this->useFormattedMessage = (bool) $value;
     }
 }

--- a/src/Monolog/Handler/PushoverHandler.php
+++ b/src/Monolog/Handler/PushoverHandler.php
@@ -180,6 +180,6 @@ class PushoverHandler extends SocketHandler
      */
     public function useFormattedMessage($value)
     {
-        $this->useFormattedMessage = (bool) $value;
+        $this->useFormattedMessage = (boolean) $value;
     }
 }


### PR DESCRIPTION
This change allows you to use the formatted version of the event from your formatter.  This is helpful if you want to create a formatter that would include _some_ context information beyond the message itself.

Since the default `LineFormatter` would be too verbose, I added a `useFormattedMessage()` method that accepts a boolean and would turn the use of the formatter on or off. This way, if you want to use a custom formatter, you can enable the functionality...but it will still work the same out of the box otherwise with just the message getting sent to Pushover.
